### PR TITLE
Added width and height to image elements for covers in lists

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -83,6 +83,15 @@ class Image:
     def __repr__(self):
         return "<image: %s/%d>" % (self.category, self.id)
 
+    def width(self):
+        """Get the width of the image."""
+        info = self.info()
+        return info["width"] if info else None
+    
+    def height(self):
+        """Get the height of the image."""
+        info = self.info()
+        return info["height"] if info else None
 
 ThingKey = str
 

--- a/openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js
@@ -231,9 +231,10 @@ function getSeedType(seed) {
  * @param {string} seedKey
  * @param {string} listTitle
  * @param {string} [coverUrl]
+ * @param {string} desiredHeight 
  * @returns {HTMLLIElement}
  */
-export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl = DEFAULT_COVER_URL) {
+export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl = DEFAULT_COVER_URL, desiredHeight = "") {
     if (!i18nStrings) {
         const i18nInput = document.querySelector('input[name=list-i18n-strings]')
         i18nStrings = JSON.parse(i18nInput.value)
@@ -244,7 +245,7 @@ export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl =
     const seedType = getSeedType(seedKey)
 
     const itemMarkUp = `<span class="image">
-                <a href="${listKey}"><img src="${coverUrl}" alt="${i18nStrings['cover_of']}${listTitle}" title="${i18nStrings['cover_of']}${listTitle}"/></a>
+                <a href="${listKey}"><img src="${coverUrl}" alt="${i18nStrings['cover_of']}${listTitle}" title="${i18nStrings['cover_of']}${listTitle}" width="22px" height="${desiredHeight}"/></a>
             </span>
             <span class="data">
                 <span class="label">

--- a/openlibrary/plugins/openlibrary/js/my-books/index.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/index.js
@@ -7,7 +7,7 @@ import { removeChildren } from '../utils'
 
 // XXX : jsdoc
 // XXX : decompose
-export function initMyBooksAffordances(dropperElements, showcaseElements) {
+export async function initMyBooksAffordances(dropperElements, showcaseElements) {
     const showcases = []
     for (const elem of showcaseElements) {
         const showcase = new ShowcaseItem(elem)
@@ -42,7 +42,7 @@ export function initMyBooksAffordances(dropperElements, showcaseElements) {
 
     getListPartials()
         .then(response => response.json())
-        .then((data) => {
+        .then(async (data) => {
             // XXX : convert this block to one or two function calls
             const listData = data.listData
             const activeShowcaseItems = []
@@ -55,8 +55,18 @@ export function initMyBooksAffordances(dropperElements, showcaseElements) {
                         const key = listData[listKey].members[0]
                         const coverID = key.slice(key.indexOf('OL'))
                         const cover = `https://covers.openlibrary.org/b/olid/${coverID}-S.jpg`
-
-                        activeShowcaseItems.push(createActiveShowcaseItem(listKey, seedKey, listData[listKey].listName, cover))
+                        
+                        const img = new Image()
+                        img.src = cover
+                        
+                        await new Promise((resolve) => {
+                            img.onload = () => {
+                                let desiredHeight = 22 * img.height / img.width
+                                desiredHeight = desiredHeight.toFixed(2)
+                                activeShowcaseItems.push(createActiveShowcaseItem(listKey, seedKey, listData[listKey].listName, cover, desiredHeight))
+                                resolve()
+                            }
+                        })
                     }
                 }
             }

--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -36,7 +36,16 @@ $var title: $_('Lists')
                         <div class="cover">
                             $ cover = list.get_cover() or list.get_default_cover()
                             $ cover_url = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
-                            <img src="$cover_url" alt=""/>
+                            <!-- Get the original width and height of cover image-->
+                            $ cover_width = cover.width()
+                            $ cover_height = cover.height()
+                            <!-- Get the aspect ratio of cover image for resizing -->
+                            $ cover_aspect_ratio = cover_width and cover_height and cover_width / cover_height
+                            <!-- Calculate the width of cover image for 58px height (58px is the height of each cover image of size S) -->
+                            $ cover_width_for_58px_height = cover_aspect_ratio and int(58 * cover_aspect_ratio)
+                            <!-- Calculate the height of cover image for 25px width (25px is the width of each cover image in list view) -->
+                            $ cover_height_for_25px_width = cover_width_for_58px_height and round(1450 / cover_width_for_58px_height)
+                            <img src="$cover_url" alt="" width="25px" height="$cover_height_for_25px_width" />
                         </div>
                         $list.name
                     </a>

--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -36,14 +36,10 @@ $var title: $_('Lists')
                         <div class="cover">
                             $ cover = list.get_cover() or list.get_default_cover()
                             $ cover_url = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
-                            <!-- Get the original width and height of cover image-->
                             $ cover_width = cover.width()
                             $ cover_height = cover.height()
-                            <!-- Get the aspect ratio of cover image for resizing -->
                             $ cover_aspect_ratio = cover_width and cover_height and cover_width / cover_height
-                            <!-- Calculate the width of cover image for 58px height (58px is the height of each cover image of size S) -->
                             $ cover_width_for_58px_height = cover_aspect_ratio and int(58 * cover_aspect_ratio)
-                            <!-- Calculate the height of cover image for 25px width (25px is the width of each cover image in list view) -->
                             $ cover_height_for_25px_width = cover_width_for_58px_height and round(1450 / cover_width_for_58px_height)
                             <img src="$cover_url" alt="" width="25px" height="$cover_height_for_25px_width" />
                         </div>

--- a/static/css/components/listLists.less
+++ b/static/css/components/listLists.less
@@ -29,7 +29,7 @@ ul.listLists {
       /* stylelint-disable max-nesting-depth */
       img {
         width: 32px;
-        max-width: 100%;
+        // max-width: 100%;
       }
       /* stylelint-enable max-nesting-depth */
     }

--- a/static/css/components/listLists.less
+++ b/static/css/components/listLists.less
@@ -28,7 +28,7 @@ ul.listLists {
       padding: 0 10px;
       /* stylelint-disable max-nesting-depth */
       img {
-        width: 32px;
+        width: 22px;
         // max-width: 100%;
       }
       /* stylelint-enable max-nesting-depth */

--- a/static/css/layout/index.less
+++ b/static/css/layout/index.less
@@ -13,7 +13,7 @@ div.contentBody,
 div#contentBody {
   padding: 0 @contentBody-padding @contentBody-padding;
   img {
-    max-width: 100%;
+    // max-width: 100%;
   }
   pre {
     overflow-x: auto;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
- Added width and height attributes to the img element for covers in the "Active Lists" section.
- Added width and height attributes to the img element for covers in the already-lists component.
- Remove max-width constraint for img elements in lists.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. docker compose up
2. Go to http://localhost:8080/lists. 
3. Maybe, you will need to modify the code of the function `_get_active_lists_in_random(limit=20, preload=True)` as follows:
![image](https://github.com/user-attachments/assets/1caa67fc-8efe-48ae-9e87-4fdc8bba9234) 
This is to show all the lists in the "Active Lists" section if you have few lists in your database.
4. Inspect a cover of a book in "Active Lists" section. 
5. Then, look at the img element. It should have a widht and a height attribute. 
6. Go to a page of a particular book or work, add it to a new list or an existing list and, then inspect the cover. Repeat step 5.
7. On this same page of a particular book, clic on "Lists" or go to the "List" section in book details, inspect a cover and look at the styles of the img element, it should have a width = "22px".
![image](https://github.com/user-attachments/assets/8cfa24ca-1ef9-44b4-9f01-03498c519033)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->



### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Image 1 - Active Lists
![image](https://github.com/user-attachments/assets/7afcb0a6-d689-4382-aa66-de1279e6219e)

Image 2 - Lists in already-lists component
![image](https://github.com/user-attachments/assets/3487c691-cd8c-41ef-9be9-e9e4c5d7898d)

Image 3 - List section in the details of a book
![image](https://github.com/user-attachments/assets/d7d69e8e-190f-4425-9635-48410ee94f41)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
