### PR TITLE
Fix linter issues

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js
@@ -231,10 +231,10 @@ function getSeedType(seed) {
  * @param {string} seedKey
  * @param {string} listTitle
  * @param {string} [coverUrl]
- * @param {string} desiredHeight 
+ * @param {string} desiredHeight
  * @returns {HTMLLIElement}
  */
-export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl = DEFAULT_COVER_URL, desiredHeight = "") {
+export function createActiveShowcaseItem(listKey, seedKey, listTitle, coverUrl = DEFAULT_COVER_URL, desiredHeight = '') {
     if (!i18nStrings) {
         const i18nInput = document.querySelector('input[name=list-i18n-strings]')
         i18nStrings = JSON.parse(i18nInput.value)

--- a/openlibrary/plugins/openlibrary/js/my-books/index.js
+++ b/openlibrary/plugins/openlibrary/js/my-books/index.js
@@ -55,10 +55,10 @@ export async function initMyBooksAffordances(dropperElements, showcaseElements) 
                         const key = listData[listKey].members[0]
                         const coverID = key.slice(key.indexOf('OL'))
                         const cover = `https://covers.openlibrary.org/b/olid/${coverID}-S.jpg`
-                        
+
                         const img = new Image()
                         img.src = cover
-                        
+
                         await new Promise((resolve) => {
                             img.onload = () => {
                                 let desiredHeight = 22 * img.height / img.width


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This pull request resolves linter issues including:
- The use of single quotes for the desiredHeight paramater default value in `createActiveShowcaseItem` function in the `ShowcaseItem.js` file. 
- Remove trailing spaces in `openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js (line 234)`
- Remove trailing spaces in `openlibrary/plugins/openlibrary/js/my-books/index.js (lines 58 and 61)`

### Technical
<!-- What should be noted about the implementation? -->
* [`openlibrary/plugins/openlibrary/js/lists/ShowcaseItem.js`](diffhunk://#diff-f6c0a0b834d41cb91867bfec28d67c23bc6727494f01a3addf64eaccd9abba7aL237-R237): Changed the default value of the `desiredHeight` parameter from double quotes to single quotes in the `createActiveShowcaseItem` function.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verified that the linter issues are resolved and no new issues are introduced.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
