### PR TITLE
Remove width property from bookver element in SearchResultsWork file

### DIFF
--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -101,7 +101,7 @@
   }
   .imageLg {
     text-align: center;
-    width: 6rem;
+    width: 100%;
     margin: 10px 10px 0 5px;
     img {
       max-width: 6rem;

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -85,13 +85,11 @@
     }
   }
   .bookcover {
-    width: 100%;
     margin: 10px 10px 0 5px;
     text-align: center;
     overflow: hidden;
     img {
       border-radius: 4px;
-      max-width: 100%;
       max-height: 300px;
       width: 175px;
     }
@@ -103,10 +101,10 @@
   }
   .imageLg {
     text-align: center;
-    width: 100%;
+    width: 6rem;
     margin: 10px 10px 0 5px;
     img {
-      max-width: 100%;
+      max-width: 6rem;
       max-height: 110px;
     }
   }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1747,8 +1747,7 @@ div#subjectLists {
     padding: 0;
     color: @link-blue;
     border-bottom: 1px solid @link-blue;
-    margin-bottom: 
-    px;
+    margin-bottom: 15px;
   }
 }
 

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1747,7 +1747,8 @@ div#subjectLists {
     padding: 0;
     color: @link-blue;
     border-bottom: 1px solid @link-blue;
-    margin-bottom: 15px;
+    margin-bottom: 
+    px;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR removes the `width` property from the `<img>` element inside the `bookcover` class in the `SearchResultsWork` file to ensure that images can adapt their size based on their natural dimensions, improving responsiveness and load times.

### Technical
<!-- What should be noted about the implementation? -->
- The removal of the `width` attribute allows the image to scale naturally according to its original dimensions.
- This change will help in maintaining better layout consistency across different screen sizes and formats (S, M, L).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to the search results page where book covers are displayed.
2. Verify that the images load correctly without distortion or unexpected sizing.
3. Check that all image formats (small, medium, large) display properly and maintain their aspect ratios.


