### PR TITLE
Fixes the height of the cover in editions main page

### DIFF
--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -13,10 +13,30 @@ $ cover_lg = book.get_cover_url("L")
 $ src = cover_url or '/images/icons/avatar_book.png'
 $ srcset = '%s 2x' % (cover_lg or '/images/icons/avatar_book-lg.png')
 
+$ cover_height = None
+$ cover_width = 180  # Fixed width of the image
+$ aspect_ratio = 1
+$ cover = book.get_cover()
+$if cover:
+    $ cover_height = cover.height()
+    $ cover_width = cover.width()
+    $ aspect_ratio = cover.width() / cover.height()
+$else:
+    $ ia_cover_url = book.get_ia_cover(book.ocaid, "M")
+    $ parts = ia_cover_url.split('_h')
+    $ cover_height_str = parts[1].split('.')[0]
+    $ cover_height = int(cover_height_str)
+    $ cover_width_str = parts[0].split('_w')[1]
+    $ cover_width = int(cover_width_str)
+    $ aspect_ratio = cover_width / cover_height
+
+$ fixed_width = 180  # Fixed width of the container
+$ calculated_height = fixed_width / aspect_ratio
+
 $if preload:
     $add_metatag(tag="link", **{'rel': 'preload', 'as': 'image', 'href': src, 'imagesrcset': srcset})
 
-<div class="coverMagic cover-animation">
+<div class="coverMagic cover-animation" style="min-height: ${calculated_height}px;">
     <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
         <a
             href="$cover_lg"


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature: no reflow of the elements below the cover image of an edition
