### PR TITLE
Estandarización de tamaños de las portadas de libros en carruseles

### DIFF
--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -29,7 +29,7 @@
     margin: 0 auto;
     box-shadow: 1px 2px 5px 0 @book-cover-shadow-color;
     border-radius: 3px;
-    max-width: 100%;
-    max-height: 200px;
+    width: 100%;
+    height: 12rem;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Standarization of sizes on carousel book covers

### Technical
<!-- What should be noted about the implementation? -->
Simple CSS manipulation

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Select or search a book and look for the related books ("You might also like"). You might need to minimize in order to get the carousel view

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![01e1800ffc5bda19652ce48c21792ece](https://github.com/user-attachments/assets/92ef5490-6782-4c3d-b2a6-9060f3e9ee24)
![b667a4d286a05b1b14702308232327f4](https://github.com/user-attachments/assets/2797d4e3-43f1-4b9c-8650-09ed3121e109)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
