### PR TITLE
A new container is added and the size of the covers is standardized

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -5,8 +5,12 @@
         <slot name="cover-label" v-bind:book="book"/>
       </template>
 
-      <template v-slot:cover="{book}">
-        <slot name="cover" v-bind:book="book"/>
+      <template v-slot:cover="{book}"> 
+        <div class="cover-container"> 
+          <slot name="cover" v-bind:book="book"> 
+              <img :src="`https://covers.openlibrary.org/b/id/${book.cover_i}-L.jpg`" alt="Cover" class="cover"/> 
+          </slot> 
+        </div> 
       </template>
 
       <template #book-end-start>
@@ -251,7 +255,6 @@ export default {
 };
 </script>
 
-
 <style scoped>
 .load-books {
   width: 100%;
@@ -319,4 +322,42 @@ export default {
   overflow: clip;
   position: relative;
 }
+
+.cover-container {
+  width: 180px;
+  height: 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+img.cover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+@media (max-width: 600px) {
+  .cover-container {
+    width: 100px;
+    height: 150px;
+  }
+}
+
+@media (min-width: 601px) and (max-width: 1200px) {
+  .cover-container {
+    width: 120px;
+    height: 180px;
+  }
+}
+
+@media (min-width: 1201px) {
+  .cover-container {
+    width: 150px;
+    height: 200px;
+  }
+}
+
 </style>

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -4,7 +4,7 @@
       <template v-slot:cover-label="{book}">
         <slot name="cover-label" v-bind:book="book"/>
       </template>
-      
+
       <template v-slot:cover="{book}">
         <div class="cover-container">
           <slot name="cover" v-bind:book="book">

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -4,13 +4,13 @@
       <template v-slot:cover-label="{book}">
         <slot name="cover-label" v-bind:book="book"/>
       </template>
-
-      <template v-slot:cover="{book}"> 
-        <div class="cover-container"> 
-          <slot name="cover" v-bind:book="book"> 
-              <img :src="`https://covers.openlibrary.org/b/id/${book.cover_i}-L.jpg`" alt="Cover" class="cover"/> 
-          </slot> 
-        </div> 
+      
+      <template v-slot:cover="{book}">
+        <div class="cover-container">
+          <slot name="cover" v-bind:book="book">
+            <img :src="`https://covers.openlibrary.org/b/id/${book.cover_i}-L.jpg`" alt="Cover" class="cover"/>
+          </slot>
+        </div>
       </template>
 
       <template #book-end-start>


### PR DESCRIPTION
Closes #5

Standardizing the size of the covers in the browser carousel>

### Technical
CSS and HTML manipulation

### Screenshot
![Captura de pantalla 2024-12-12 184512](https://github.com/user-attachments/assets/4d976b07-bb6d-43f9-a8a9-4efe6056fe41)



