### PR TITLE
Removal of the property 'width' from the .bookcover component in the …

### DIFF
--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -84,14 +84,12 @@
       filter: blur(2px);
     }
   }
-  .bookcover {
-    width: 100%;
+  .git {
     margin: 10px 10px 0 5px;
     text-align: center;
     overflow: hidden;
     img {
       border-radius: 4px;
-      max-width: 100%;
       max-height: 300px;
       width: 175px;
     }


### PR DESCRIPTION
…static/css/components/search-result-item.less file.

<!-- What issue does this PR close? -->
Closes #4 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR removes the width property from the <img> element inside the bookcover class in the SearchResultsWork file to ensure that images can adapt their size based on their natural dimensions, improving responsiveness and load times.


### Technical
The removal of the width attribute allows the image to scale naturally according to its original dimensions.
This change will help in maintaining better layout consistency across different screen sizes and formats (S, M, L).

### Testing
Navigate to the search results page where book covers are displayed.
Verify that the images load correctly without distortion or unexpected sizing.
Check that all image formats (small, medium, large) display properly and maintain their aspect ratios.



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
